### PR TITLE
Feature/docs-n-paths

### DIFF
--- a/src/clj/gulo/harvest.clj
+++ b/src/clj/gulo/harvest.clj
@@ -42,7 +42,7 @@
   [^DarwinCoreRecord rec]
   (map fix-val (prepend-uuid rec)))
 
-(defn url->csv
+(defn url->file
   "Convert Darwin Core Archive at supplied URL into tab delimited file
   at path."
   [path url]
@@ -59,4 +59,4 @@
   "Harvest Darwin Core Archives from URLs into a tab delimited file at
   path."
   [urls path]
-  (map (partial url->csv path) urls))
+  (map (partial url->file path) urls))

--- a/src/clj/gulo/main.clj
+++ b/src/clj/gulo/main.clj
@@ -17,18 +17,15 @@
 
 (defmain Shred
   [harvest-path hfs-path tables-path]
-  (let [csv-file (str harvest-path "/" "dwc.csv")
-        hfs-tax (str hfs-path "/" "tax")
-        tax-part (str hfs-tax "/part-00000")
-        hfs-loc (str hfs-path "/" "loc")
-        loc-part (str hfs-loc "/part-00000")
-        hfs-tax-loc (str hfs-path "/" "tax-loc")
-        tax-loc-part (str hfs-tax-loc "/part-00000")
-        hfs-occ (str hfs-path "/" "occ")]
+  (let [csv-file (str harvest-path "/dwc.csv")
+        hfs-tax (str hfs-path "/tax")
+        hfs-loc (str hfs-path "/loc")
+        hfs-tax-loc (str hfs-path "/tax-loc")
+        hfs-occ (str hfs-path "/occ")]
     (location-table (hfs-textline csv-file) hfs-loc)
     (taxon-table (hfs-textline csv-file) hfs-tax)
-    (tax-loc-table csv-file tax-part loc-part hfs-tax-loc)
-    (occ-table csv-file tax-part loc-part tax-loc-part hfs-occ)))
+    (tax-loc-table csv-file hfs-tax hfs-loc hfs-tax-loc)
+    (occ-table csv-file hfs-tax hfs-loc hfs-tax-loc hfs-occ)))
 
 (defn PrepareTables
   []


### PR DESCRIPTION
In this pull request I've tweaked a few docs to clarify delimiters (comma vs. tab) and simplified path definitions (e.g. hfs-tax and hfs-tax-loc). On this latter change, there's no need to specify part file names - Hadoop will shred anything in the directory you point it at.
