### PR TITLE
added constant metadata tag in the definition of constant variables

### DIFF
--- a/src/clj/gulo/core.clj
+++ b/src/clj/gulo/core.clj
@@ -7,10 +7,10 @@
   (:import [org.gbif.dwc.record DarwinCoreRecord]))
 
 ;; Position of values in a split texline.
-(def OCC-ID 0)
-(def LAT 22)
-(def LON 23)
-(def SCINAME 160)
+(def ^:const OCC-ID 0)
+(def ^:const LAT 22)
+(def ^:const LON 23)
+(def ^:const SCINAME 160)
 
 (defn- my-filter [& vals] (println (str "VAL--------------" vals)) true)
 


### PR DESCRIPTION
I've only done this in core.clj.  There may be other candidates, but I am not sure how this tag will interact with cascalog.  Next step: run the tests after `(set! *warn-on-reflection* true)`.  See if there are strange reflections.  The metadata tag will avoid undue reflections, as described [here](http://clojurefun.wordpress.com/).
