### PR TITLE
Now use metadata from CartoDB to populate orgname

### DIFF
--- a/src/clj/gulo/harvest.clj
+++ b/src/clj/gulo/harvest.clj
@@ -162,6 +162,7 @@
         ipt (url->field "ipt" url)
         networks (url->networks url)
         coll-count (url->field "collectioncount" url)
+        org-name (url->field "orgname" url)
         eml-url (util/resource-url->eml-url url)
         eml (EmlFactory/build (io/input-stream eml-url))
         row {:title (.getTitle eml)
@@ -171,7 +172,7 @@
              :eml eml-url
              :dwca (s/replace url "resource" "archive")
              :pubdate (.toString (.getPubDate eml))
-             :orgname (.getOrganisation (.getContact eml))
+             :orgname org-name
              :description (.getAbstract eml)
              :emlrights (.getIntellectualRights eml)
              :contact (.getCreatorName eml)


### PR DESCRIPTION
Addresses [issue 358](https://github.com/VertNet/webapp/issues/358) from @laurarussell.
