### PR TITLE
Feature/truncate

### DIFF
--- a/src/clj/gulo/harvest.clj
+++ b/src/clj/gulo/harvest.clj
@@ -201,7 +201,7 @@
   "Sync resource table on CartoDB by populating from EML and resource_staging."
   []
   (let [urls (get-resource-urls STAGING-TABLE)]
-    (cartodb/query (format "TRUNCATE TABLE %s RESTART IDENTITY) "vertnet" :api-key util/api-key)
+    (cartodb/query (format "TRUNCATE TABLE %s RESTART IDENTITY" HARVEST-TABLE) "vertnet" :api-key util/api-key)
     (doall
      (map sync-resource urls))))
 


### PR DESCRIPTION
Using TRUNCATE instead of DELETE FROM for efficiency and no need to VACUUM. Also making identities restart on load for convenience.
